### PR TITLE
Improve GitHub caching

### DIFF
--- a/.github/workflows/static-validate.yml
+++ b/.github/workflows/static-validate.yml
@@ -9,44 +9,40 @@ jobs:
     name: Static Validation
     runs-on: ubuntu-latest
     steps:
+      - name: DateAndTimeStamps
+        id: stamps
+        run: |
+          set -euo pipefail
+          timestamp=$(date +'%Y%m%dT%H%M%S')
+          datestamp=$(date +'%Y%m%d')
+          echo "TIMESTAMP=${timestamp}" | tee -a "$GITHUB_OUTPUT"
+          echo "DATESTAMP=${datestamp}" | tee -a "$GITHUB_OUTPUT"
       - uses: actions/checkout@v4
       - name: Tool cache
         uses: actions/cache@v4
         with:
           path: |
             ${{ runner.temp }}/bin
-          key: ${{ runner.os }}-usr-local-bin
+          key: ${{ runner.os }}-tools-${{ hashFiles('ci-tools/install-tools.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-tools-
       - name: Install tools
         run: |
           set -euo pipefail
-          mkdir -p ${{ runner.temp }}/bin
-          pushd ${{ runner.temp }}/bin
-          if ! [ -f ./eget ]; then
-            $GITHUB_WORKSPACE/ci-tools/eget.sh
-          fi
-          if ! [ -f ./kubeconform ]; then
-            ./eget --upgrade-only yannh/kubeconform
-          fi
-          if ! [ -f ./tk ]; then
-            ./eget --upgrade-only grafana/tanka
-            mv tanka tk
-          fi
-          if ! [ -f ./jb ]; then
-            ./eget --upgrade-only jsonnet-bundler/jsonnet-bundler
-            mv jsonnet-bundler jb
-          fi
-          if ! [ -f ./helm ]; then
-            ./eget --upgrade-only https://get.helm.sh/helm-v3.18.2-linux-amd64.tar.gz --file helm
-          fi
-          popd
+          export TOOLDIR=${{ runner.temp }}/bin
+          export GET_EGET=$GITHUB_WORKSPACE/ci-tools/eget.sh
+          $GITHUB_WORKSPACE/ci-tools/install-tools.sh
       - name: Find modules
         id: modules
         run: |
           set -euo pipefail
+          # Locate Helm and Tanka configs for validation
           charts=($(find "${{ github.workspace }}" -name Chart.yaml -exec dirname {} \;))
           echo "CHARTS=${charts[*]}" | tee -a "$GITHUB_OUTPUT"
           tanka=($(find "${{ github.workspace }}" -name jsonnetfile.json -exec dirname {} \;))
           echo "TANKA=${tanka[*]}" | tee -a "$GITHUB_OUTPUT"
+
+          # Cache vendor directories
           for c in "${!charts[@]}"; do
               charts[c]="${charts[c]}/charts"
           done
@@ -65,12 +61,17 @@ jobs:
         with:
           path: |
             ${{ runner.temp }}/cache/kubeconform
-          key: ${{ runner.os }}-kubeconform
+          key: ${{ runner.os }}-kubeconform-${{ steps.stamps.outputs.TIMESTAMP }}
+          restore-keys: |
+            ${{ runner.os }}-kubeconform-${{ steps.stamps.outputs.DATESTAMP }}
+            ${{ runner.os }}-kubeconform-
       - name: Deps cache
         uses: actions/cache@v4
         with:
           path: ${{ steps.modules.outputs.CACHE_DIRS }}
-          key: ${{ runner.os }}-deps
+          key: ${{ runner.os }}-deps-${{ hashFiles('**/Chart.lock', '**/jsonnetfile.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-deps-
       - name: Check Tanka
         run: |
           set -euxo pipefail

--- a/apprise/environments/default/main.jsonnet
+++ b/apprise/environments/default/main.jsonnet
@@ -18,7 +18,7 @@ local apprise = {
     // Ref https://github.com/caronc/apprise-api#environment-variables
     envSecret: 'apprise-env',
     htpasswdSecret: 'apprise-admin',
-    port: kPort.new('https', 8000),
+    port: kPort.new('http', 8000),
     ingressAnnotations: {
       'cert-manager.io/cluster-issuer': 'real-cert',
     },

--- a/ci-tools/install-tools.sh
+++ b/ci-tools/install-tools.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+TOOLDIR="${TOOLDIR:-/usr/local/bin}"
+DEFAULT_EGET="curl https://zyedidia.github.io/eget.sh | sh"
+GET_EGET="${GET_EGET:-$DEFAULT_EGET}"
+
+echo "GET_EGIT=${GET_EGET}"
+mkdir -p "${TOOLDIR}"
+pushd "${TOOLDIR}" > /dev/null
+if ! [ -f ./eget ]; then
+  bash -c $GET_EGET
+fi
+if ! [ -f ./kubeconform ]; then
+  ./eget --upgrade-only yannh/kubeconform
+fi
+if ! [ -f ./tk ]; then
+  ./eget --upgrade-only grafana/tanka
+  mv tanka tk
+fi
+if ! [ -f ./jb ]; then
+  ./eget --upgrade-only jsonnet-bundler/jsonnet-bundler
+  mv jsonnet-bundler jb
+fi
+if ! [ -f ./helm ]; then
+  ./eget --upgrade-only https://get.helm.sh/helm-v3.18.2-linux-amd64.tar.gz --file helm
+fi
+popd > /dev/null


### PR DESCRIPTION
The static cache keys meant the contents were fixed at whatever it was the first time it succeeded. Now mostly from hashes, except kubeconform which is just date- / time-based.