### PR TITLE
allow ipv6 get get apprise to shut up

### DIFF
--- a/apprise/application.yaml
+++ b/apprise/application.yaml
@@ -19,9 +19,9 @@ spec:
     server: https://kubernetes.default.svc
     namespace: apprise
   syncPolicy:
-    # automated:
-    #   prune: true
-    #   selfHeal: true
+    automated:
+      prune: true
+      selfHeal: true
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true

--- a/apprise/environments/default/main.jsonnet
+++ b/apprise/environments/default/main.jsonnet
@@ -64,7 +64,8 @@ local apprise = {
         kContainer.new(config.name, std.format('%s:%s', [config.image, config.version]))
         + kContainer.withPorts([config.port])
         + kContainer.withEnvMap({
-          IPV4_ONLY: 'yes',
+          // The nginx config explicitly listens and forwards ipv6.
+          // IPV4_ONLY: 'yes',
           APPRISE_STATELESS_STORAGE: 'yes',
           APPRISE_ATTACH_SIZE: '500',
           APPRISE_STATEFUL_MODE: 'simple',


### PR DESCRIPTION
The nginx config https://github.com/caronc/apprise-api/blob/master/apprise_api/etc/nginx.conf refers to ipv6 directly