### PR TITLE
Add hostnames to public DNS

### DIFF
--- a/external-dns/templates/talos-names.yaml
+++ b/external-dns/templates/talos-names.yaml
@@ -1,0 +1,29 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: talos-control
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: talos-control.local.symmatree.com
+spec:
+  type: ExternalName
+  externalName: talos-control-1.local.symmatree.com
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: talos-control-1
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: talos-control-1.local.symmatree.com
+spec:
+  type: ExternalName
+  externalName: 10.0.1.50
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: talos-worker-1
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: talos-worker-1.local.symmatree.com
+spec:
+  type: ExternalName
+  externalName: 10.0.1.100


### PR DESCRIPTION
DNS was split between Google Cloud DNS and local, this puts the k8s hostnames in cloud for consistency.

Also this avoids a dependency on local DNS for the Github Runner to work (though local DNS also *should* work!)