### PR TITLE
Loki gateway readiness probe

### DIFF
--- a/loki/values.yaml
+++ b/loki/values.yaml
@@ -57,6 +57,13 @@ loki:
         secretAccessKey: ${SECRET_ACCESS_KEY}
         accessKeyId: ${ACCESS_KEY_ID}
         s3ForcePathStyle: true
+  gateway:
+    readinessProbe:
+      httpGet:
+        path: /ready
+        port: 80
+      initialDelaySeconds: 3
+      periodSeconds: 3
   # We have minio at home.
   minio:
     enabled: false


### PR DESCRIPTION
Change to :80/ready instead of metricsPort default:   https://github.com/grafana/loki/blob/main/production/helm/loki/values.yaml#L1166