### PR TITLE
Dashboard validation, disable CPU and Memory Overcommit alerts

### DIFF
--- a/.pint.hcl
+++ b/.pint.hcl
@@ -4,6 +4,11 @@ parser {
   relaxed = [ "(.*)"]
 }
 
+checks {
+  disabled = [
+    "promql/regexp",  # Triggers on default values that happen to be literal strings
+    ]
+}
 prometheus "tales-mimir" {
   uri = "https://mimir.local.symmatree.com/prometheus"
   required = true

--- a/ci-tools/check-dashboards.sh
+++ b/ci-tools/check-dashboards.sh
@@ -16,5 +16,7 @@ python "$WORKSPACE/../dashpint/extract.py" "--grafana-token=$TOKEN" "--grafana-u
 # Move to work_dir so we can use "find ." to generate relative paths for input and output.
 cd "$WORK_DIR"
 # NOTE: pint doesn't write to stdout, we need stderr
-find . -name "*.yaml" -exec \
-	pint --no-color --config "$WORKSPACE/.pint.hcl" --log-level info lint --json "$REPORT_DIR/$(basename "{}" .yaml).json" --min-severity warning "{}" \;
+# shellcheck disable=SC2156
+find . -name "*.yaml" \
+	-exec bash -c 'mkdir -p "$(dirname /home/jovyan/pint-report/{})"' \; \
+	-exec pint --no-color --config "$WORKSPACE/.pint.hcl" --log-level info lint --json "$REPORT_DIR/{}.json" --min-severity warning "{}" \;

--- a/ci-tools/check-dashboards.sh
+++ b/ci-tools/check-dashboards.sh
@@ -16,7 +16,8 @@ python "$WORKSPACE/../dashpint/extract.py" "--grafana-token=$TOKEN" "--grafana-u
 # Move to work_dir so we can use "find ." to generate relative paths for input and output.
 cd "$WORK_DIR"
 # NOTE: pint doesn't write to stdout, we need stderr
+# 1 worker to keep from melting mimir.
 # shellcheck disable=SC2156
 find . -name "*.yaml" \
 	-exec bash -c 'mkdir -p "$(dirname /home/jovyan/pint-report/{})"' \; \
-	-exec pint --no-color --config "$WORKSPACE/.pint.hcl" --log-level info lint --json "$REPORT_DIR/{}.json" --min-severity warning "{}" \;
+	-exec pint --workers 1 --no-color --config "$WORKSPACE/.pint.hcl" --log-level info lint --json "$REPORT_DIR/{}.json" --min-severity warning "{}" \;

--- a/ci-tools/check-dashboards.sh
+++ b/ci-tools/check-dashboards.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")" >/dev/null
+CI_TOOLS=$(pwd)
+WORKSPACE=$(dirname "$CI_TOOLS")
+echo "WORKSPACE: $WORKSPACE"
+
+TOKEN=$(op read op://tales-secrets/grafana-prom-metrics-check-token/TOKEN)
+GRAFANA=https://borgmon.local.symmatree.com
+WORK_DIR=/tmp/rules
+REPORT_DIR="$HOME/pint-report"
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+mkdir -p "$REPORT_DIR"
+python "$WORKSPACE/../dashpint/extract.py" "--grafana-token=$TOKEN" "--grafana-url=$GRAFANA" "--out-dir=$WORK_DIR"
+# Move to work_dir so we can use "find ." to generate relative paths for input and output.
+cd "$WORK_DIR"
+# NOTE: pint doesn't write to stdout, we need stderr
+find . -name "*.yaml" -exec \
+	pint --no-color --config "$WORKSPACE/.pint.hcl" --log-level info lint --json "$REPORT_DIR/$(basename "{}" .yaml).json" --min-severity warning "{}" \;

--- a/ci-tools/check-mimir-rules.sh
+++ b/ci-tools/check-mimir-rules.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")" >/dev/null
+CI_TOOLS=$(pwd)
+WORKSPACE=$(dirname "$CI_TOOLS")
+echo "WORKSPACE: $WORKSPACE"
+
+WORK_DIR=/tmp/rules
+REPORT_DIR="$HOME/pint-report"
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR"
+mkdir -p "$REPORT_DIR"
+mimirtool rules print \
+	--address=https://mimir.local.symmatree.com --id=anonymous \
+	--output-dir="$WORK_DIR"
+# Move to work_dir so we can use "find ." to generate relative paths for input and output.
+cd "$WORK_DIR"
+# NOTE: pint doesn't write to stdout, we need stderr
+# 1 worker to keep from melting mimir.
+# shellcheck disable=SC2156
+find . -name "*.yaml" \
+	-exec bash -c 'mkdir -p "$(dirname /home/jovyan/pint-report/{})"' \; \
+	-exec pint --workers 1 --no-color --config "$WORKSPACE/.pint.hcl" --log-level info lint --json "$REPORT_DIR/{}.json" --min-severity warning "{}" \;

--- a/mimir/README.md
+++ b/mimir/README.md
@@ -75,8 +75,6 @@ mimirtool alertmanager get \
 This is actually testing the upstream alert definitions / configs (e.g. kubernetes-mixin),
 but the mechanics of testing are at the mimir level.
 
-By hand at present:
-
 One-time setup:
 
 ```
@@ -86,18 +84,6 @@ sudo eget https://github.com/cloudflare/pint --asset=pint-linux-amd64
 sudo mv pint-linux-amd64 pint
 ```
 
-```
-export OUT_DIR=/tmp/rules
-mkdir -p "$OUT_DIR"
-mimirtool rules print \
-  --address=https://mimir.local.symmatree.com --id=anonymous \
-  --output-dir="$OUT_DIR"
-```
+then run `ci-tools/check-mimir-rules.sh`
 
-then (from the root directory of the repo because that's where `.pint.hcl` lives),
-
-```
-export TARGET=kubernetes-mixin
-pint lint -n info \
-  "${OUT_DIR}/alloy_${TARGET}*"
-```
+See also `ci-tools/check-dashboards.sh` which connects Grafana dashboards to the same checks.

--- a/tanka/environments/kubernetes-mixin/main.jsonnet
+++ b/tanka/environments/kubernetes-mixin/main.jsonnet
@@ -28,8 +28,14 @@ libMonResources.new(
     dashboardsToDrop: [
       'proxy',
     ],
-    rulesToDrop: [
+    ruleGroupsToDrop: [
       'kubernetes-system-kube-proxy',
     ],
+    alertsToDrop: {
+      'kubernetes-resources': [
+        'KubeCPUOvercommit',  // Fires if you cannot spare the largest node.
+        'KubeMemoryOvercommit',  // Fires if you cannot spare the largest node.
+      ],
+    },
   },
 )


### PR DESCRIPTION
Adds ci-tools scripts to check dashboards and PrometheusRules using `pint` which is slow but fierce.