### PR TITLE
Keep node exporter metrics used by mixin

### DIFF
--- a/.pint.hcl
+++ b/.pint.hcl
@@ -16,6 +16,6 @@ prometheus "tales-mimir" {
 # https://cloudflare.github.io/pint/checks/promql/series.html
 check "promql/series" {
   lookbackRange           = "2d"
-  ignoreMetrics           = [ "(.*)", ... ]
-  ignoreLabelsValue       = { "...": [ "...", ... ] }
+  # ignoreMetrics           = [ "(.*)", ... ]
+  # ignoreLabelsValue       = { "...": [ "...", ... ] }
 }

--- a/.pint.hcl
+++ b/.pint.hcl
@@ -13,3 +13,9 @@ prometheus "tales-mimir" {
   uri = "https://mimir.local.symmatree.com/prometheus"
   required = true
 }
+# https://cloudflare.github.io/pint/checks/promql/series.html
+check "promql/series" {
+  lookbackRange           = "2d"
+  ignoreMetrics           = [ "(.*)", ... ]
+  ignoreLabelsValue       = { "...": [ "...", ... ] }
+}

--- a/alloy/values.yaml
+++ b/alloy/values.yaml
@@ -31,6 +31,22 @@ k8s-monitoring:
     windows-exporter:
       enabled: false
       deploy: false
+    node-exporter:
+      enabled: true
+      deploy: true
+      metricsTuning:
+        useDefaultAllowList: true
+        useIntegrationAllowList: true
+        includeMetrics:
+          - "node_pressure.*"
+          - "node_xfs.*"
+        dropMetricsForFilesystem:
+          - ramfs
+          - tmpfs
+          - nsfs
+          - overlayfs
+      extraArgs:
+        - --collector.filesystem.fs-types-exclude=^(ramfs|tmpfs|nsfs|overlayfs)$
     kepler:
       enabled: false
     opencost:


### PR DESCRIPTION
Partially addresses #97 then we can re-run before allow-listing labels and metrics to be ignored in the future