### PR TITLE
Fix tempo url

### DIFF
--- a/alloy/values.yaml
+++ b/alloy/values.yaml
@@ -22,7 +22,7 @@ k8s-monitoring:
       url: http://loki-gateway.loki.svc/loki/api/v1/push
     - name: localTempo
       type: otlp
-      url: http://tempo-frontend.tempo.svc:4318/api/traces
+      url: http://tempo.tempo.svc:4318/api/traces
       "logs.enabled": false
       "metrics.enabled": false
   # https://github.com/grafana/k8s-monitoring-helm/blob/main/charts/k8s-monitoring/charts/feature-cluster-metrics/values.yaml


### PR DESCRIPTION
Tempo's service is just named tempo since we're not distributed-tempo